### PR TITLE
for mac

### DIFF
--- a/download_mac.cmd
+++ b/download_mac.cmd
@@ -1,0 +1,6 @@
+wget -nc -P trex "https://raw.githubusercontent.com/BabylonJS/Exporters/master/Maya/Samples/glTF%202.0/T-Rex/mtl_trex_baseColor.jpg"
+wget -nc -P trex "https://raw.githubusercontent.com/BabylonJS/Exporters/master/Maya/Samples/glTF%202.0/T-Rex/mtl_trex_emissive.jpg"
+wget -nc -P trex "https://raw.githubusercontent.com/BabylonJS/Exporters/master/Maya/Samples/glTF%202.0/T-Rex/mtl_trex_metallicRoughness.jpg"
+wget -nc -P trex "https://raw.githubusercontent.com/BabylonJS/Exporters/master/Maya/Samples/glTF%202.0/T-Rex/trex_nml.png"
+wget -nc -P trex "https://raw.githubusercontent.com/BabylonJS/Exporters/master/Maya/Samples/glTF%202.0/T-Rex/trex_running.bin"
+wget -nc -P trex "https://raw.githubusercontent.com/BabylonJS/Exporters/master/Maya/Samples/glTF%202.0/T-Rex/trex_running.gltf"

--- a/main.js
+++ b/main.js
@@ -7,6 +7,11 @@ const electron = require('electron'),
 let mainWindow
 
 function createWindow() {
+  let fullscreen = true
+  if (process.platform === 'darwin') {
+    fullscreen = false
+  }
+
   const size = electron.screen.getPrimaryDisplay().size
   mainWindow = new BrowserWindow({
     left: 0,
@@ -19,7 +24,7 @@ function createWindow() {
     alwaysOnTop: true,
     ignoreMouseEvents: true,
     maximize: true,
-    fullscreen: true,
+    fullscreen: fullscreen,
     focusable: false,
     skipTaskbar: true,
     transparent: true,


### PR DESCRIPTION
macだとフルスクリーンになってプロセスが奪われてしまう感じでしたが、fullscreenをfalseにしたら動くようになりました。

あとencodeの解釈の違いで素材が落とせなかったので別ファイルで`download_mac.cmd`を作りました
（`download.cmd`内で分岐したほうがよかったかもしれませんが、、、）

下記動きました
![image](https://user-images.githubusercontent.com/1576894/50038841-50953580-006a-11e9-8647-40deb05e5b2c.png)
